### PR TITLE
Fix presetIndex assignment in SoundFontInstrument constructor

### DIFF
--- a/android/src/main/cpp/Engine/SoundFontInstrument.h
+++ b/android/src/main/cpp/Engine/SoundFontInstrument.h
@@ -12,7 +12,7 @@ public:
     int presetIndex;
 
     SoundFontInstrument(int32_t sampleRate, bool isStereo, const char* path, bool isAsset, int32_t presetIndex) {
-        presetIndex = presetIndex;
+        this->presetIndex = presetIndex;
 
         if (isAsset) {
             auto asset = openAssetBuffer(path);


### PR DESCRIPTION
I was hearing no sound when trying to use my sound fonts and figured out the `presetIndex` is never correctly set and we get an UB.