### PR TITLE
fix for "fatal error: 'sfizz.hpp' file not found" on ios release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,6 @@
 ## 0.4.2
 * Remove hard-coded FLUTTER_ROOT in example iOS app
 * Run `flutter format`
+
+## 0.4.3
+* Fix for sfizz.hpp file not found on ios release build

--- a/ios/flutter_sequencer.podspec
+++ b/ios/flutter_sequencer.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_sequencer'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/ios/flutter_sequencer.podspec
+++ b/ios/flutter_sequencer.podspec
@@ -29,7 +29,7 @@ A new flutter plugin project.
     'DEFINES_MODULE' => 'YES',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64,i386',
     'STRIP_STYLE' => 'non-global',
-    'HEADER_SEARCH_PATHS' => '"${PROJECT_DIR}/../../.."/ios/third_party/sfizz/src'
+    'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/third_party/sfizz/src'
   }
   s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   s.swift_version = '5.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_sequencer
-version: 0.4.2
+version: 0.4.3
 description: >-
   A Flutter plugin for sequencing audio. Use it to build sequences of notes and play them back using
   SFZ or SF2 sound fonts.


### PR DESCRIPTION
please consider this change to podspec to run XCode release build